### PR TITLE
Fix cli! based on new semantics

### DIFF
--- a/src/puppetlabs/utils.clj
+++ b/src/puppetlabs/utils.clj
@@ -449,6 +449,20 @@
 
 ;; ## Command-line parsing
 
+(defn fail-with-missing-cli-arg!
+  "Helper function that prints a failure message when a required CLI arg
+  is missing, prints a usage message, and then exits.
+
+  We mostly have this separated into its own function in order to make it possible
+  to write tests against the rest of the logic without worrying about the
+  System/exit call in here."
+  [missing-field banner]
+  (println)
+  (println (format "Missing required argument '--%s'!" (name missing-field)))
+  (println)
+  (println banner)
+  (System/exit 1))
+
 (defn cli!
   "Validates that required command-line arguments are present.  If they are not,
   exits with an error and displays usage information.  Input:
@@ -471,11 +485,7 @@
       (println banner)
       (System/exit 0))
     (when-let [missing-field (some #(if (not (contains? options %)) %) required-args)]
-      (println)
-      (println (format "Missing required argument '--%s'!" (name missing-field)))
-      (println)
-      (println banner)
-      (System/exit 1))
+      (fail-with-missing-cli-arg! missing-field banner))
     [options extras]))
 
 

--- a/test/puppetlabs/utils_test.clj
+++ b/test/puppetlabs/utils_test.clj
@@ -234,6 +234,15 @@
                 {:foo {:bar "baz"}
                  :bar {:bar "goo"}})))))))
 
+(deftest cli-parsing
+  (testing "Should call `fail-with-missing-cli-arg!` if a required option is missing"
+    (let [fail-status (atom {})]
+      (with-redefs [fail-with-missing-cli-arg! (fn [missing-field _]
+                                                 (reset! fail-status {:missing-field missing-field}))]
+        (cli! [] [["-r"]] [:required])
+        (is (= (@fail-status :missing-field) :required))))))
+
+
 (deftest cert-utils
   (testing "extracting cn from a dn"
     (is (thrown? AssertionError (cn-for-dn 123))


### PR DESCRIPTION
Apparently, there were some changes introduced in 0.2.2 of
`org.clojure/tools.logging` that affected some of the behavior
of the cli validation that we were doing in our `utils` namespace.

PuppetDB is patching this here:

https://github.com/puppetlabs/puppetdb/pull/751/files

This commit simply brings that same change over to kitchensink,
since it'll be needed when we submit the PR to move PuppetDB
over to kitchensink.
