### PR TITLE
Add basic travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: clojure
+lein: lein2
+jdk:
+  - oraclejdk7
+  - openjdk7
+  - openjdk6
+script: ./ext/travisci/test.sh
+notifications:
+  email: false
+services: postgresql

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+lein2 test


### PR DESCRIPTION
This includes a basic .travis.yml file for testing against the following JVM
variants:
- openjdk7
- oracle7
- openjdk6

Although we are looking at dropping 6 for future projects, PuppetDB still uses
this so its worth covering.

It also adds the test script to ext/travisci/test.sh which for now just runs
'lein2 test'.

Success for these tests can be seen here: https://travis-ci.org/kbarber/clj-kitchensink/builds/14196480

Signed-off-by: Ken Barber ken@bob.sh
