### PR TITLE
(PE-2408) Add namespaces to slingshot exceptions

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -354,6 +354,15 @@
 
 ;; ## Exception handling
 
+(defn without-ns
+  "Given a clojure keyword that is optionally namespaced, returns
+  a keyword with the same name but with no namespace."
+  [kw]
+  {:pre [(keyword? kw)]
+   :post [(keyword? %)
+          (nil? (namespace %))]}
+  (keyword (name kw)))
+
 (defn keep-going*
   "Executes the supplied fn repeatedly. Execution may be stopped with an
   InterruptedException."
@@ -509,7 +518,7 @@
                                       ["-h" "--help" "Show help" :default false :flag true])
         [options extras banner] (apply cli/cli args specs)]
     (when (:help options)
-      (throw+ {:type ::help
+      (throw+ {:type ::cli-help
                :message banner}))
     (when-let [missing-field (some #(if (not (contains? options %)) %) required-args)]
       (let [msg (str
@@ -517,7 +526,7 @@
                   (format "Missing required argument '--%s'!" (name missing-field))
                   "\n\n"
                   banner)]
-        (throw+ {:type ::error
+        (throw+ {:type ::cli-error
                  :message msg})))
     [options extras]))
 

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -192,6 +192,14 @@
       (testing "should still match"
         (is (= input output))))))
 
+(deftest without-ns-test
+  (testing "removes namespace from a namespaced keyword"
+    (is (= :foo (without-ns :foo/foo)))
+    (is (= :foo (without-ns ::foo))))
+  (testing "doesn't alter non-namespaced keyword"
+    (let [kw :foo]
+      (is (= kw (without-ns kw))))))
+
 (deftest string-hashing
   (testing "Computing a SHA-1 for a UTF-8 string"
     (testing "should fail if not passed a string"
@@ -253,7 +261,8 @@
         (cli! [] [["-r" "--required" "A required field"]] [:required])
         (catch map? m
           (is (contains? m :type))
-          (is (= :puppetlabs.kitchensink.core/error (:type m)))
+          (is (= :puppetlabs.kitchensink.core/cli-error (:type m)))
+          (is (= :cli-error (without-ns (:type m))))
           (is (contains? m :message))
           (reset! got-expected-error true)))
       (is (true? @got-expected-error))))
@@ -264,7 +273,8 @@
         (cli! ["--help"] [] [])
         (catch map? m
           (is (contains? m :type))
-          (is (= :puppetlabs.kitchensink.core/help (:type m)))
+          (is (= :puppetlabs.kitchensink.core/cli-help (:type m)))
+          (is (= :cli-help (without-ns (:type m))))
           (is (contains? m :message))
           (reset! got-expected-help true)))
       (is (true? @got-expected-help))))


### PR DESCRIPTION
This makes them more easily identifiable when the code is used
in other projects.
