### PR TITLE
Refactor PEM code to remove need for provider

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  [digest "1.4.3"]
                  [clj-time "0.5.1"]
                  ;; SSL
-                 [org.bouncycastle/bcpkix-jdk15on "1.49"]]
+                 [org.bouncycastle/bcpkix-jdk15on "1.50"]]
 
   :profiles {:dev {:resource-paths ["test-resources"]}}
 


### PR DESCRIPTION
With this change, it is no longer necessary to register the
BouncyCastleProvider as a JVM-wide security provider in order to
read/write PEM files.  This eliminates the possibility that
the BC provider will be used for SSL operations where we are
not explicitly asking for it to be used (such as by Jetty,
when decrypting HTTPS requests).
