### PR TITLE
Add JSON Utils from PuppetDB

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,9 @@
                  [clj-time "0.5.1"]
                  [slingshot "0.10.3"]
                  ;; SSL
-                 [org.bouncycastle/bcpkix-jdk15on "1.50"]]
+                 [org.bouncycastle/bcpkix-jdk15on "1.50"]
+                 ;; JSON
+                 [cheshire "5.2.0"]]
 
   ;; By declaring a classifier here and a corresponding profile below we'll get an additional jar
   ;; during `lein jar` that has all the code in the test/ directory. Downstream projects can then
@@ -39,7 +41,7 @@
 
   :lein-release        {:scm          :git
                         :deploy-via   :lein-deploy}
-  
+
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
                                      :password :env/clojars_jenkins_password

--- a/src/puppetlabs/kitchensink/json.clj
+++ b/src/puppetlabs/kitchensink/json.clj
@@ -1,0 +1,91 @@
+(ns ^{:doc "Cheshire related functions
+
+  This front-ends the common set of core cheshire functions:
+
+  * generate-string
+  * generate-stream
+  * parse-string
+  * parse-stream
+
+  This namespace when 'required' will also setup some common JSON encoders
+  globally, so you can avoid doing this for each call."}
+
+  puppetlabs.kitchensink.json
+  (:require [cheshire.generate :as generate]
+            [cheshire.core :as core]
+            [clj-time.coerce :as coerce]
+            [clj-time.core :as clj-time]
+            [clojure.java.io :as io]
+            [clojure.tools.logging :as log]))
+
+(defn- clj-time-encoder
+  [data jsonGenerator]
+  (.writeString jsonGenerator (coerce/to-string data)))
+
+(def ^:dynamic *datetime-encoder* clj-time-encoder)
+
+(defn add-common-json-encoders!*
+  "Non-memoize version of add-common-json-encoders!"
+  []
+  (when (satisfies? generate/JSONable (clj-time/date-time 1999))
+    (log/warn "Overriding existing JSONable protocol implementation for org.joda.time.DateTime"))
+  (generate/add-encoder
+    org.joda.time.DateTime
+    (fn [data jsonGenerator]
+      (*datetime-encoder* data jsonGenerator))))
+
+(def
+  ^{:doc "Registers some common encoders for cheshire JSON encoding.
+
+  This is a memoize function, to avoid unnecessary calls to add-encoder.
+
+  Ideally this function should be called once in your apply, for example your
+  main class.
+
+  Encoders currently include:
+
+  * org.joda.time.DateTime - handled with to-string"}
+  add-common-json-encoders! (memoize add-common-json-encoders!*))
+
+(defmacro with-datetime-encoder
+  "Evaluates the body using the given encoder to serialize DateTime objects to
+  JSON. Requires that `add-common-json-encoders!` from this namespace has
+  already been called, and that nobody else has re-extended
+  org.joda.date.DateTime to cheshire's JSONable protocol in the meantime."
+  [encoder & body]
+  `(binding [*datetime-encoder* ~encoder]
+     ~@body))
+
+(def default-pretty-opts {:date-format "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" :pretty true})
+
+(def ^String generate-string core/generate-string)
+
+(def ^String generate-stream core/generate-stream)
+
+(defn generate-pretty-string
+  "Thinly wraps cheshire.core/generate-string, adding the clj-time default date
+  format and pretty printing from `default-pretty-opts`"
+  ([obj]
+     (generate-pretty-string obj default-pretty-opts))
+  ([obj opts]
+     (generate-string obj (merge default-pretty-opts opts))))
+
+(defn generate-pretty-stream
+  "Thinly wraps cheshire.core/generate-stream, adding the clj-time default date
+  format and pretty printing from `default-pretty-opts`"
+  ([obj writer]
+     (generate-pretty-stream obj writer default-pretty-opts))
+  ([obj writer opts]
+     (generate-stream obj writer (merge default-pretty-opts opts))))
+
+(def parse-string core/parse-string)
+
+(def parse-stream core/parse-stream)
+
+(defn spit-json
+  "Similar to clojure.core/spit, but writes the Clojure
+   datastructure as JSON to `f`"
+  [f obj & options]
+  (with-open [writer (apply io/writer f options)]
+    (generate-pretty-stream obj writer))
+  nil)

--- a/test/puppetlabs/kitchensink/json_test.clj
+++ b/test/puppetlabs/kitchensink/json_test.clj
@@ -1,0 +1,73 @@
+(ns puppetlabs.kitchensink.json-test
+  (:require [cheshire.generate :refer [remove-encoder]]
+            [clj-time.core :as clj-time]
+            [clojure.tools.logging :as log]
+            [fs.core :as fs]
+            [puppetlabs.kitchensink.testutils :refer [temp-file]])
+  (:import (java.io StringWriter StringReader))
+  (:use clojure.test
+        puppetlabs.kitchensink.json))
+
+(defn add-common-encoders-fixture
+  [f]
+  (add-common-json-encoders!*)
+  (f))
+
+(use-fixtures :once add-common-encoders-fixture)
+
+(deftest test-with-custom-datetime-encoder
+  (testing "should allow use of custom encoder"
+    (is (= (with-datetime-encoder (fn [dt gn8r] (.writeString gn8r "Beer-o-clock"))
+             (generate-string (clj-time/date-time 1989 11 17 5 6 24 654)))
+           "\"Beer-o-clock\""))))
+
+(deftest test-generate-string
+  (testing "should generate a json string"
+    (is (= (generate-string {:a 1 :b 2})
+            "{\"a\":1,\"b\":2}")))
+  (testing "should generate a json string that has a Joda DataTime object in it and not explode"
+    (is (= (generate-string {:a 1 :b (clj-time/date-time 1986 10 14 4 3 27 456)})
+            "{\"a\":1,\"b\":\"1986-10-14T04:03:27.456Z\"}"))))
+
+(deftest test-generate-pretty-string
+  (testing "should generate a json string"
+    (is (= (generate-pretty-string {:a 1 :b 2})
+            "{\n  \"a\" : 1,\n  \"b\" : 2\n}")))
+  (testing "should generate a json string that has a Joda DataTime object in it and not explode"
+    (is (= (generate-pretty-string {:a 1 :b (clj-time/date-time 1986 10 14 4 3 27 456)})
+           "{\n  \"a\" : 1,\n  \"b\" : \"1986-10-14T04:03:27.456Z\"\n}"))))
+
+(deftest test-generate-stream
+  (testing "should generate a json string from a stream"
+    (let [sw (StringWriter.)]
+      (generate-stream {:a 1 :b 2} sw)
+      (is (= (.toString sw)
+              "{\"a\":1,\"b\":2}")))))
+
+(deftest test-generate-pretty-stream
+  (testing "should generate a pretty printed json string from a stream"
+    (let [sw (StringWriter.)]
+      (generate-pretty-stream {:a 1 :b 2} sw)
+      (is (= (.toString sw)
+             "{\n  \"a\" : 1,\n  \"b\" : 2\n}")))))
+
+(deftest test-parse-string
+  (testing "should return a map from parsing a json string"
+    (is (= (parse-string "{\"a\":1,\"b\":2}")
+            {"a" 1 "b" 2}))))
+
+(deftest test-parse-stream
+  (testing "should return  map from parsing a json stream"
+    (is (= (parse-stream (StringReader. "{\"a\":1,\"b\":2}"))
+            {"a" 1 "b" 2}))))
+
+(deftest test-spit-json
+  (let [json-out (temp-file "spit-json")]
+    (testing "json output with keywords"
+      (spit-json json-out {:a 1 :b 2})
+      (is (= "{\n  \"a\" : 1,\n  \"b\" : 2\n}"
+             (slurp json-out))))
+    (testing "json output with strings"
+      (spit-json json-out {"a" 1 "b" 2})
+      (is (= "{\n  \"a\" : 1,\n  \"b\" : 2\n}"
+             (slurp json-out))))))

--- a/test/puppetlabs/kitchensink/testutils.clj
+++ b/test/puppetlabs/kitchensink/testutils.clj
@@ -1,4 +1,5 @@
-(ns puppetlabs.kitchensink.testutils)
+(ns puppetlabs.kitchensink.testutils
+  (:require [fs.core :as fs]))
 
 (defn call-counter
   "Returns a method that just tracks how many times it's called, and
@@ -20,3 +21,18 @@
   invoked."
   [f]
   (deref (:ncalls (meta f))))
+
+(defn delete-on-exit
+  "Will delete `f` on shutdown of the JVM"
+  [f]
+  (do
+    (.addShutdownHook (java.lang.Runtime/getRuntime) (Thread. #(fs/delete-dir f)))
+    f))
+
+(def ^{:doc "Creates a temporary file that will be deleted on JVM shutdown."}
+  temp-file
+  (comp delete-on-exit fs/temp-file))
+
+(def ^{:doc "Creates a temporary directory that will be deleted on JVM shutdown."}
+  temp-dir
+  (comp delete-on-exit fs/temp-dir))


### PR DESCRIPTION
These are general enough that there's no reason for them to be in PuppetDB, and the [mq library](https://github.com/puppetlabs/mq) I'm also spinning out of PuppetDB relies on it, so there's even a good reason for them not to be in PuppetDB (currently I have them pasted in to mq, but once this PR is merged in I can stop doing that).

One unsavory thing about this PR is that it duplicates PuppetDB's `temp-file` test utility. I'll be opening up another PR on TrapperKeeper to add that to its test utils.
