### PR TITLE
Add deep-merge & deep-merge-with

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -229,6 +229,29 @@
         (recur ret (first ks) (next ks))
         ret))))
 
+(defn deep-merge
+  "Deeply merges maps so that nested maps are combined rather than replaced.
+
+  For example:
+  (deep-merge {:foo {:bar :baz}} {:foo {:fuzz :buzz}})
+  ;;=> {:foo {:bar :baz, :fuzz :buzz}}
+
+  ;; contrast with clojure.core/merge
+  (merge {:foo {:bar :baz}} {:foo {:fuzz :buzz}})
+  ;;=> {:foo {:fuzz :quzz}} ; note how last value for :foo wins"
+  [& vs]
+  (if (every? map? vs)
+    (apply merge-with deep-merge vs)
+    (last vs)))
+
+(defn deep-merge-with
+  "Deeply merges like `deep-merge`, but uses `f` to produce a value from the
+  conflicting values for a key in multiple maps."
+  [f & vs]
+  (if (every? map? vs)
+    (apply merge-with (partial deep-merge-with f) vs)
+    (apply f vs)))
+
 (defn keyset
   "Returns the set of keys from the supplied map"
   [m]

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -117,6 +117,18 @@
     (testing "should not remove the key if the value is not nil"
       (is (= testmap (dissoc-if-nil testmap :a))))))
 
+(deftest deep-merge-test
+  (testing "should deeply nest duplicate keys that both have map values"
+    (let [testmap-1 {:foo {:bar :baz}, :pancake :flapjack}
+          testmap-2 {:foo {:fuzz {:buzz :quux}}}]
+      (is (= {:foo {:bar :baz, :fuzz {:buzz :quux}}, :pancake :flapjack}
+             (deep-merge testmap-1 testmap-2)))))
+  (testing "should combine duplicate keys' values that aren't all maps by
+           calling the provided function"
+    (let [testmap-1 {:foo {:bars 2}}
+          testmap-2 {:foo {:bars 3, :bazzes 4}}]
+      (is (= {:foo {:bars 5, :bazzes 4}} (deep-merge-with + testmap-1 testmap-2))))))
+
 (deftest missing?-test
   (let [sample {:a "asdf" :b "asdf" :c "asdf"}]
     (testing "should return true for single key items if they don't exist in the coll"


### PR DESCRIPTION
These differ from merge in that they will recursively merge maps that appear at the same key for multiple merged maps, instead of just replacing the maps wholesale with the last value (like merge does).

We are using these in the Node Classifier, but they seemed general enough to go in here.
