### PR TITLE
Return summary data from cli!

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -535,7 +535,14 @@
 
   ** The map is thrown using 'slingshot' (https://github.com/scgilardi/slingshot).
   It contains a `:type` and `:message`, where type is either `:error` or `:help`,
-  and the message is either the error message or a help banner."
+  and the message is either the error message or a help banner.
+
+  Returns a three-item vector, containing:
+  * a map of the parsed options
+  * a vector containing the remaining cli arguments that were not parsed
+  * a string containing a summary of all of the options that are available; for
+    use in printing help messages if the user detects that the arguments are
+    still invalid in some way."
   ([args specs] (cli! args specs nil))
   ([args specs required-args]
   (let [specs (conj specs ["-h" "--help" "Show help" :default false :flag true])
@@ -560,7 +567,7 @@
                   summary)]
         (throw+ {:type ::cli-error
                  :message msg})))
-    [options arguments])))
+    [options arguments summary])))
 
 
 ;; ## SSL Certificate handling

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -291,13 +291,22 @@
           (reset! got-expected-help true)))
       (is (true? @got-expected-help))))
 
-  (testing "Should return a map after parsing CLI args"
-    (let [cli-data (first (cli! ["-a" "1234 Sunny ave." "-g" "Hey, what's up?"]
-                                [["-g" "--greeting" "A string to greet somebody"]
-                                 ["-a" "--address" "Somebody's address"]] []))]
+  (testing "Should return options map, remaining args, and summary after parsing CLI args"
+    (let [[cli-data remaining-args summary] (cli! ["-a" "1234 Sunny ave." "--greeting" "Hey, what's up?" "--toggle" "extra-arg"]
+                                               [["-g" "--greeting GREETING" "A string to greet somebody"]
+                                                ["-a" "--address ADDRESS" "Somebody's address"]
+                                                ["-t" "--toggle" "A flag/boolean option"]] [])]
       (is (map? cli-data))
-      (is (contains? cli-data :address))
-      (is (contains? cli-data :greeting))))
+      (is (= "1234 Sunny ave." (cli-data :address)))
+      (is (= "Hey, what's up?" (cli-data :greeting)))
+      (is (= true (cli-data :toggle)))
+      (is (vector? remaining-args))
+      (is (= ["extra-arg"] remaining-args))
+      (is (= (str "  -g, --greeting GREETING  A string to greet somebody\n"
+                  "  -a, --address ADDRESS    Somebody's address\n"
+                  "  -t, --toggle             A flag/boolean option\n"
+                  "  -h, --help               Show help")
+             summary))))
 
   (testing "Errors reported by tools.cli should be thrown out of cli! as slingshot exceptions"
     (let [got-expected-exception (atom false)]


### PR DESCRIPTION
Prior to this commit, the banner/summary data generated by
the upstream `parse-cli` function was not being returned as part
of the result of our `cli!` function.  This meant that if a user
wanted to do some additional validation of the cli arguments
(such as validating extra arguments that are left over after the
options parsing), they had no way to print the help message
if that validation failed.

This commit changes the code to return that summary data
in addition to the other data it was already returning.
It also improves the test coverage and docstring.

The changes should hopefully be backwards-compatible.
