### PR TITLE
Raise error on duplicate config entries

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,9 @@
   ;; code that we have.
   :classifiers [["test" :testutils]]
 
-  :profiles {:dev {:test-paths ["test-resources"]}
+  :profiles {:dev {:test-paths ["test-resources"]
+                   :dependencies [[spyscope "0.1.4"]]
+                   :injections [(require 'spyscope.core)]}
              :testutils {:source-paths ^:replace ["test"]}}
 
   ;; this plugin is used by jenkins jobs to interrogate the project version

--- a/test/puppetlabs/kitchensink/testutils.clj
+++ b/test/puppetlabs/kitchensink/testutils.clj
@@ -25,9 +25,8 @@
 (defn delete-on-exit
   "Will delete `f` on shutdown of the JVM"
   [f]
-  (do
-    (.addShutdownHook (java.lang.Runtime/getRuntime) (Thread. #(fs/delete-dir f)))
-    f))
+  (.deleteOnExit (fs/file f))
+  f)
 
 (def ^{:doc "Creates a temporary file that will be deleted on JVM shutdown."}
   temp-file


### PR DESCRIPTION
Prior to this commit, if a setting appeared more than once in
a section of an inifile, the last appearance would silently "win".
Further, when calling inis-to-map and pointing it at a directory
of ini files, we were sorting the files by name, and if a section
appeared in more than one file then the final config would contain
the section as it appeared in the file that was read last.  This
required the user to know that we were sorting in this fashion,
and also to understand details of the sort (such as how upper
case was sorted compared to lower case).

This behavior required the user to have a fairly intimate
understanding of the algorithm, and did not give the user any
indication when collisions occurred.  It seems more likely that
if a setting appeared in multiple places in the config, that it
was simply a mistake / accident on the part of the user.

This commit changes the behavior in the following ways:
- If a section appears in more than one ini file, the final
  configuration contains a merge of the contents of all of the
  appearances of that section.
- If duplicate occurrences of a setting occur within a given section
  (either in a single ini file or across two ini files), an error
  is raised indicating where the duplicate setting occurred.
