### PR TITLE
(PE-3680) Fixup failing tests due to missed rebase on merge of PE-3673

### DIFF
--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -64,12 +64,12 @@
 
 (deftest mkdirs-test
   (testing "creates all specified directories that don't exist"
-    (let [tmpdir (testutils/temp-dir)]
+    (let [tmpdir (temp-dir)]
       (fs/mkdirs (fs/file tmpdir "foo"))
       (mkdirs! (fs/file tmpdir "foo" "bar" "baz"))
       (is (fs/directory? (fs/file tmpdir "foo" "bar" "baz")))))
   (testing "throws exception if one of the elements of the path exists and is a file"
-    (let [tmpdir (testutils/temp-dir)]
+    (let [tmpdir (temp-dir)]
       (fs/mkdirs (fs/file tmpdir "foo"))
       (fs/touch (fs/file tmpdir "foo" "bar"))
       (try+
@@ -82,7 +82,7 @@
           (is (contains? m :message))
           (is (re-find #"foo/bar' is a file" (:message m)))))))
   (testing "Permission denied on some directory in the hierarchy"
-    (let [tmpdir (testutils/temp-dir)]
+    (let [tmpdir (temp-dir)]
       (fs/mkdirs (fs/file tmpdir "foo"))
       (fs/chmod "-w" (fs/file tmpdir "foo"))
       (try+


### PR DESCRIPTION
A pull request pertaining to work on PE-3673 was merged without first
rebasing based on conflicting changes from a pull request merged for
PE-3266.  This commit fixes up the failing tests to address the
conflict.
