### PR TITLE
Add to-sentence string formatter.

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -106,6 +106,33 @@
     (pprint x w)
     (.toString w)))
 
+(defn to-sentence
+  "Join the given strings as they would be listed in a sentence (using an Oxford
+  comma if there are three or more strings).
+  Examples:
+    [\"apple\"] => \"apple\"
+    [\"apple\" \"orange\"] => \"apple and orange\"
+    [\"apple\" \"orange\" \"banana\"] => \"apple, orange, and banana\""
+  [strings]
+  (let [num-strings (count strings)]
+    (cond
+      (empty? strings)
+      ""
+
+      (= num-strings 1)
+      (first strings)
+
+      (= num-strings 2)
+      (str (first strings) " and " (second strings))
+
+      (= num-strings 3)
+      (let [[s0 s1 s2] strings]
+        (str s0 ", " s1 ", and " s2))
+
+      (> num-strings 3)
+      (str (first strings) ", " (to-sentence (rest strings))))))
+
+
 ;; ## I/O
 
 (defn lines

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -86,6 +86,14 @@
                          false? nil
                          false? "FALSE"))
 
+(deftest to-sentence-test
+  (are [coll string] (= string (to-sentence coll))
+       [] ""
+       ["foo"] "foo"
+       ["foo" "bar"] "foo and bar"
+       ["foo" "bar" "baz"] "foo, bar, and baz"
+       ["foo" "bar" "baz" "qux"] "foo, bar, baz, and qux"))
+
 (deftest mkdirs-test
   (testing "creates all specified directories that don't exist for File arg"
     (let [tmpdir (temp-dir)]


### PR DESCRIPTION
Add the to-sentence function to the core namespace, which formats
a sequential collection of strings as an english sentence, akin to
rails's to_sentence.
