### PR TITLE
Add walk-leaves function.

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -362,6 +362,11 @@ to be a zipper."
         (when-not (empty? res)
           res)))))
 
+(defn walk-leaves
+  "Walk a map applying a function to all leaf nodes"
+  [m f]
+  (mapvals #(if (map? %) (walk-leaves % f) (f %)) m))
+
 (defn merge-with-key
   "Returns a map that consists of the rest of the maps conj-ed onto
   the first.  If a key `k` occurs in more than one map, the mapping(s)

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -256,6 +256,10 @@
     (testing "should remove the empty map"
       (is (= {:a {:b 1}} (dissoc-in testmap [:a :c :d]))))))
 
+(deftest walk-leaves-test
+  (testing "should apply a function to all of the leaves"
+    (is (= {:a 2 :b {:c 5}} (walk-leaves {:a 1 :b {:c 4}} inc)))))
+
 (deftest merge-with-key-test
   (let [m1        {:a 1 :b 2}
         m2        {:a 3 :b 4}


### PR DESCRIPTION
Add a walk-leaves function to the core namespace which applies
a function to all leaf nodes of a map.