### PR TITLE
Add `with-timeout` macro

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -601,6 +601,12 @@ to be a zipper."
      (catch Throwable e#
        (deliver ~error e#))))
 
+(defmacro with-timeout [timeout-s default & body]
+  `(let [f# (future (do ~@body))
+         result# (deref f# (* 1000 ~timeout-s) ~default)]
+     (future-cancel f#)
+     result#))
+
 ;; ## Temp files
 
 (defn temp-file-name

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -713,3 +713,15 @@
                     :setting2 "hi"
                     :bunk     "bizzle"}}
              (inis-to-map tempdir))))))
+
+(deftest timeout-test
+  (let [wait-return (fn [time val] (Thread/sleep time) val)]
+    (testing "with-timeout"
+      (testing "does nothing if the body returns within the limit"
+        (is (= true
+               (with-timeout 1 false
+                 (wait-return 500 true)))))
+      (testing "returns the default value if the body times out"
+        (is (= false
+               (with-timeout 1 false
+                 (wait-return 1005 true))))))))


### PR DESCRIPTION
This macro returns a default value if executing the body takes longer than the given limit in seconds.