### PR TITLE
(PE-11026) Add Support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ The code is available in a separate "test" jar that you may depend on by using a
 Copyright © 2013 Puppet Labs
 
 Distributed under the [Apache License, version 2](http://www.apache.org/licenses/).
+
+## Support
+
+Please log tickets and issues at our [Trapperkeeper JIRA tracker](https://tickets.puppetlabs.com/browse/TK).


### PR DESCRIPTION
This commit adds a Support section to the bottom of the README that
includes a link to the Trapperkeeper JIRA project for issue tracking.