### PR TITLE
(TK-315) update to raynes 1.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.1
+
+This is a maintenance release.
+
+* [TK-315](https://tickets.puppetlabs.com/browse/TK-315) - update to latest version
+  of `raynes.fs` to reduce downstream dependency conflicts.
+
 ## 1.2.0
 
 * Add `temp-file-name` function, which returns a unique name to a temporary file, 

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  ;; Logging
                  [org.clojure/tools.logging "0.2.6"]
                  ;; Filesystem utilities
-                 [me.raynes/fs "1.4.5"]
+                 [me.raynes/fs "1.4.6"]
                  ;; Configuration file parsing
                  [org.ini4j/ini4j "0.5.2"]
                  [org.clojure/tools.cli "0.3.0"]

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -726,7 +726,7 @@ to be a zipper."
                   [path]
                   (fs/glob (fs/file path glob-pattern)))]
       (->> files
-        (map fs/absolute-path)
+        (map fs/absolute)
         (map ini-to-map)
         (apply deep-merge-with-keys
                (fn [ks & _]

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -437,7 +437,7 @@
                 {:foo {:bar "baz"}})))
 
         (testing "when specified as a string"
-          (is (= (inis-to-map (fs/absolute-path tf))
+          (is (= (inis-to-map (fs/absolute tf))
                 {:foo {:bar "baz"}})))))
 
     (testing "should work for a directory"


### PR DESCRIPTION
The filesystem utils library that we depend on made a breaking API change between version 1.4.5 and 1.4.6.  This was causing issues for our downstream users who wanted to use kitchensink/TK but already had their own dependencies on `1.4.6`.  This PR updates us to the latest version of `raynes.fs` and fixes the couple of places where their API change broke things for us.