### PR TITLE
(TK-315) Add replacement for raynes `absolute-path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 1.2.1
+## 1.3.0
 
-This is a maintenance release.
+This is a maintenance / minor feature release.
 
 * [TK-315](https://tickets.puppetlabs.com/browse/TK-315) - update to latest version
   of `raynes.fs` to reduce downstream dependency conflicts.
+* Add an `absolute-path` fn to replace the one that was removed from raynes.fs
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This is a maintenance / minor feature release.
 * [TK-315](https://tickets.puppetlabs.com/browse/TK-315) - update to latest version
   of `raynes.fs` to reduce downstream dependency conflicts.
 * Add an `absolute-path` fn to replace the one that was removed from raynes.fs
+* Add a `normalized-path` fn to replace the one that was removed from raynes.fs
 
 ## 1.2.0
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/kitchensink "1.2.1-SNAPSHOT"
+(defproject puppetlabs/kitchensink "1.3.0-SNAPSHOT"
   :description "Clojure utility functions"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -7,7 +7,7 @@
 (ns puppetlabs.kitchensink.core
   (:import [org.ini4j Ini Config]
            [javax.naming.ldap LdapName]
-           [java.io StringWriter Reader IOException File])
+           [java.io StringWriter Reader File])
   (:require [clojure.test]
             [clojure.tools.logging :as log]
             [clojure.string :as string]
@@ -606,6 +606,14 @@ to be a zipper."
          result# (deref f# (* 1000 ~timeout-s) ~default)]
      (future-cancel f#)
      result#))
+
+;; ## File paths
+(defn absolute-path
+  "Replacement for raynes.fs/absolute-path, which was removed in raynes.fs 1.4.6.
+  Returns string representation of absolute path, as opposed to fs/absolute, which
+  returns a File object."
+  [path]
+  (.getPath (fs/absolute path)))
 
 ;; ## Temp files
 

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -615,6 +615,13 @@ to be a zipper."
   [path]
   (.getPath (fs/absolute path)))
 
+(defn normalized-path
+  "Replacement for raynes.fs/normalized-path, which was removed in raynes.fs 1.4.6.
+  Returns string representation of absolute path, as opposed to fs/normalized, which
+  returns a File object."
+  [path]
+  (.getPath (fs/normalized path)))
+
 ;; ## Temp files
 
 (defn temp-file-name

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -437,7 +437,7 @@
                 {:foo {:bar "baz"}})))
 
         (testing "when specified as a string"
-          (is (= (inis-to-map (fs/absolute tf))
+          (is (= (inis-to-map (absolute-path tf))
                 {:foo {:bar "baz"}})))))
 
     (testing "should work for a directory"


### PR DESCRIPTION
We were using raynes' `absolute-path` in tons of places in our
code.  It was removed in raynes.fs 1.4.6.  This commit introduces
an equivalent function to KS so that upgrading consuming projects
will be easier.