### PR TITLE
(maint) Remove unrecognized :flag option for cli tooling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [me.raynes/fs "1.4.6"]
                  ;; Configuration file parsing
                  [org.ini4j/ini4j "0.5.2"]
-                 [org.clojure/tools.cli "0.3.0"]
+                 [org.clojure/tools.cli "0.3.3"]
                  ;; This library is used by puppetlabs.kitchensink.classpath
                  ;; to do some classpath stuff.
                  [org.tcrawley/dynapath "0.2.3"]

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -816,7 +816,7 @@ to be a zipper."
     still invalid in some way."
   ([args specs] (cli! args specs nil))
   ([args specs required-args]
-  (let [specs (conj specs ["-h" "--help" "Show help" :default false :flag true])
+  (let [specs (conj specs ["-h" "--help" "Show help" :default false])
         {:keys [options arguments summary errors]} (cli/parse-opts args specs)]
     (when errors
       (let [msg (str


### PR DESCRIPTION
This commit removes the unrecognized `:flag` option for the CLI tooling
(unrecognized as of "0.3.0" of `org.clojure/tools.cli`). This commit
also bumps to the latest minor of `org.clojure/tools.cli` as well.