### PR TITLE
(MAINT) Improve classpath macro

### DIFF
--- a/src/puppetlabs/kitchensink/classpath.clj
+++ b/src/puppetlabs/kitchensink/classpath.clj
@@ -85,8 +85,8 @@
   overrides the classpath to include the specified paths; the original
   classpath is restored prior to returning."
   [jars-and-dirs & body]
-  {:pre [(coll? jars-and-dirs)
-         (every? (partial satisfies? Coercions) jars-and-dirs)]}
+  `{:pre [(coll? ~jars-and-dirs)
+         (every? (partial satisfies? Coercions) ~jars-and-dirs)]}
   `(let [orig-loader# (.. Thread currentThread getContextClassLoader)
          temp-loader# (URLClassLoader.
                         (into-array

--- a/test/puppetlabs/kitchensink/classpath_test.clj
+++ b/test/puppetlabs/kitchensink/classpath_test.clj
@@ -1,0 +1,19 @@
+(ns puppetlabs.kitchensink.classpath-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.kitchensink.classpath :refer [with-additional-classpath-entries]])
+  (:import (java.net URL)))
+
+(deftest with-additional-classpath-entries-test
+  (let [paths ["/foo" "/bar"]
+        get-urls #(into #{}
+                        (.getURLs (.getContextClassLoader (Thread/currentThread))))]
+    (with-additional-classpath-entries
+      paths
+      (testing "classloader now includes the new paths"
+        (let [urls (get-urls)]
+          (is (contains? urls (URL. "file:/foo")))
+          (is (contains? urls (URL. "file:/bar"))))))
+    (testing "classloader has been restored to its previous state"
+      (let [urls (get-urls)]
+        (is (not (contains? urls (URL. "file:/foo"))))
+        (is (not (contains? urls (URL. "file:/bar"))))))))


### PR DESCRIPTION
Previously, `with-additional-classpath-entries` didn't handle its argument
correctly in the :pre/:post section. This commit fixes that issue and also
adds a test to ensure it's cleaning up after itself