### PR TITLE
(maint) Add a helper for validating uuid in schemas

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -944,6 +944,15 @@ to be a zipper."
   []
   (str (java.util.UUID/randomUUID)))
 
+(defn uuid?
+  "Verifies whether a string is a valid UUID"
+  [uuid]
+  (try
+    (java.util.UUID/fromString uuid)
+    true
+    (catch IllegalArgumentException e
+      false)))
+
 ;; ## System interface
 
 (defn num-cpus

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -614,6 +614,12 @@
         (memoized 3)
         (is (= (testutils/times-called f) 4))))))
 
+(deftest uuid-handling
+  (testing "a generated uuid is a valid uuid"
+    (is (uuid? (uuid))))
+  (testing "a phrase is not a uuid"
+    (is (not (uuid? "Hello World")))))
+
 (deftest jvm-versions
   (testing "comparing same versions should return 0"
     (is (= 0 (compare-jvm-versions "1.7.0_3" "1.7.0_3"))))


### PR DESCRIPTION
Provides a `uuid?` helper that can be used for schema checks where we
expect to have a UUID.