### PR TITLE
(SERVER-1494) initial parent project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
+lein: 2.7.1
 jdk:
   - oraclejdk7
   - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,10 @@ jdk:
 script: ./ext/travisci/test.sh
 notifications:
   email: false
+  hipchat:
+    rooms:
+      secure: ASvt1XwEYbgkKuYZjZHytwg/6Y53Tg4T7QhohiDB4Xb1dmJueqPFpV2ko/VjHCa18JjLiUq0nWcDpRjsqaGGvJ5FSxTyyWDKtZsg1sUf4F+7aZ5vq0Dzg8Uzvdu7m9X1Uszvs9zf6wJ+Jobq4xck1xpPYxFT/+ei2Q2STrJ9xwQ=
+    template:
+      - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
+      - "Change view: %{compare_url}"
+      - "Build details: %{build_url}"

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+lein2 upgrade 2.7.1
+lein2 --version
 lein2 test

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-lein2 upgrade 2.7.1
-lein2 --version
 lein2 test

--- a/project.clj
+++ b/project.clj
@@ -38,12 +38,7 @@
 
   ;; this plugin is used by jenkins jobs to interrogate the project version
   :plugins [[lein-project-version "0.1.0"]
-            ;; using lein-step-parent for now, to workaround Cursive bug.
-            ;; need to switch back to lein-parent once Cursive supports
-            ;; lein 2.7.1 and lein-parent properly. 
-            ;[lein-parent "0.3.1"]
-            [lein-step-parent "0.1.0"]
-]
+            [lein-parent "0.3.1"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
 
   :min-lein-version "2.7.0"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.1.0-SNAPSHOT"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.1.0"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -38,7 +38,12 @@
 
   ;; this plugin is used by jenkins jobs to interrogate the project version
   :plugins [[lein-project-version "0.1.0"]
-            [lein-parent "0.3.0"]]
+            ;; using lein-step-parent for now, to workaround Cursive bug.
+            ;; need to switch back to lein-parent once Cursive supports
+            ;; lein 2.7.1 and lein-parent properly. 
+            ;[lein-parent "0.3.1"]
+            [lein-step-parent "0.1.0"]
+]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username

--- a/project.clj
+++ b/project.clj
@@ -3,27 +3,30 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
+  :min-lein-version "2.7.0"
+
+  :parent-project {:coords [puppetlabs/clj-parent "0.1.0-SNAPSHOT"]
+                   :inherit [:managed-dependencies]}
+
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 ;; Logging
-                 [org.clojure/tools.logging "0.2.6"]
-                 ;; Filesystem utilities
-                 [me.raynes/fs "1.4.6"]
-                 ;; Configuration file parsing
+  :dependencies [[org.clojure/clojure]
+                 [org.clojure/tools.logging]
+                 [org.clojure/tools.cli]
+
+                 [clj-time]
+                 [me.raynes/fs]
+                 [slingshot]
+                 [cheshire]
+
                  [org.ini4j/ini4j "0.5.2"]
-                 [org.clojure/tools.cli "0.3.3"]
-                 ;; This library is used by puppetlabs.kitchensink.classpath
-                 ;; to do some classpath stuff.
                  [org.tcrawley/dynapath "0.2.3"]
                  [digest "1.4.3"]
-                 [clj-time "0.5.1"]
-                 [slingshot "0.10.3"]
-                 ;; JSON
-                 [cheshire "5.3.1"]]
+
+                 ]
 
   ;; By declaring a classifier here and a corresponding profile below we'll get an additional jar
   ;; during `lein jar` that has all the code in the test/ directory. Downstream projects can then
@@ -34,7 +37,8 @@
   :profiles {:testutils {:source-paths ^:replace ["test"]}}
 
   ;; this plugin is used by jenkins jobs to interrogate the project version
-  :plugins [[lein-project-version "0.1.0"]]
+  :plugins [[lein-project-version "0.1.0"]
+            [lein-parent "0.3.0"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username

--- a/project.clj
+++ b/project.clj
@@ -31,9 +31,7 @@
   ;; code that we have.
   :classifiers [["test" :testutils]]
 
-  :profiles {:dev {:dependencies [[spyscope "0.1.4"]]
-                   :injections [(require 'spyscope.core)]}
-             :testutils {:source-paths ^:replace ["test"]}}
+  :profiles {:testutils {:source-paths ^:replace ["test"]}}
 
   ;; this plugin is used by jenkins jobs to interrogate the project version
   :plugins [[lein-project-version "0.1.0"]]

--- a/project.clj
+++ b/project.clj
@@ -36,11 +36,7 @@
              :testutils {:source-paths ^:replace ["test"]}}
 
   ;; this plugin is used by jenkins jobs to interrogate the project version
-  :plugins [[lein-project-version "0.1.0"]
-            [lein-release "1.0.5"]]
-
-  :lein-release        {:scm          :git
-                        :deploy-via   :lein-deploy}
+  :plugins [[lein-project-version "0.1.0"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username


### PR DESCRIPTION
FOR REVIEW - I'd like to get a few folks to test this out, with different editors, before we consider merging it.

----------------------------------------------

This commit moves us over to use the new lein 2.7.1 / lein-parent support for `:managed-dependencies`, by inheriting our dependency version numbers from a parent project.