### PR TITLE
(maint) add function for random open port

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -1025,3 +1025,9 @@ to be a zipper."
     `(let [~g ~expr
            ~@(interleave (repeat g) (map pstep forms))]
        ~g)))
+
+(defn open-port-num
+  "Returns a currently open port number"
+  []
+  (with-open [s (java.net.ServerSocket. 0)]
+    (.getLocalPort s)))

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -731,3 +731,10 @@
         (is (= false
                (with-timeout 1 false
                  (wait-return 1005 true))))))))
+
+(deftest open-port-num-test
+  (let [port-in-use (open-port-num)]
+    (with-open [s (java.net.ServerSocket. port-in-use)]
+      (let [open-ports (set (take 60000 (repeatedly open-port-num)))]
+        (is (every? pos? open-ports))
+        (is (not (contains? open-ports port-in-use)))))))


### PR DESCRIPTION
We can use this in RBAC to stop port collisions during unit tests. It's
been in PDB for a while.