### PR TITLE
(maint) add assoc-when

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -1031,3 +1031,15 @@ to be a zipper."
   []
   (with-open [s (java.net.ServerSocket. 0)]
     (.getLocalPort s)))
+
+(defmacro assoc-if-new
+  "Assocs the provided values with the corresponding keys if and only
+  if the key is not already present in map."
+  [map key val & kvs]
+  {:pre [(even? (count kvs))]}
+  (let [deferred-kvs (vec (for [[k v] (cons [key val] (partition 2 kvs))]
+                            [k `(fn [] ~v)]))]
+    `(let [updates# (for [[k# v#] ~deferred-kvs
+                          :when (= ::not-found (get ~map k# ::not-found))]
+                      [k# (v#)])]
+       (merge ~map (into {} updates#)))))

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -738,3 +738,16 @@
       (let [open-ports (set (take 60000 (repeatedly open-port-num)))]
         (is (every? pos? open-ports))
         (is (not (contains? open-ports port-in-use)))))))
+
+(deftest assoc-if-new-test
+  (testing "assoc-if-new assocs appropriately"
+    (is (= {:a "foo"}
+           (assoc-if-new {:a "foo"} :a "bar")))
+    (is (= {:a "bar" :b "foo"}
+           (assoc-if-new {:b "foo"}  :a "bar")))
+    (is (= {:a "foo" :b "bar"}
+           (assoc-if-new {} :a "foo" :b "bar")))
+    (is (= {:a "foo" :b nil}
+           (assoc-if-new {:b nil} :a "foo" :b "bar")))
+    (is (= {:a "foo" :b "baz"}
+           (assoc-if-new {:b "baz"} :a "foo" :b "bar")))))


### PR DESCRIPTION
assoc-when is a macrofrom the PDB codebase that behaves as assoc
does only if the key does not exist in the map already. If the key
already exists in the map, it's a noop.