### PR TITLE
Update to dynapath 0.2.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [cheshire]
 
                  [org.ini4j/ini4j "0.5.2"]
-                 [org.tcrawley/dynapath "0.2.4"]
+                 [org.tcrawley/dynapath "0.2.5"]
                  [digest "1.4.3"]
 
                  ]


### PR DESCRIPTION
This version addresses two Java 9 related issues:

* 0.2.4 would fail under Java 9 if AOT'd
* the latest Java 9 build (9-ea+148) broke dynapath's reflection to make
  URLClassLoader modifiable