### PR TITLE
(maint) Add `rand-str` function.

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -8,8 +8,7 @@
   (:import [org.ini4j Ini Config BasicProfileSection]
            [javax.naming.ldap LdapName]
            [java.io StringWriter Reader File])
-  (:require [clojure.test]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [clojure.string :as string]
             [clojure.tools.cli :as cli]
             [clojure.java.io :as io]

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -259,6 +259,48 @@ to be a zipper."
       (last weights-and-values)
       (-> (first selected) second))))
 
+(def ascii-character-sets
+  (let [concatv (comp vec concat)
+        ALPHA (mapv char (range 65 91))
+        alpha (mapv char (range 97 123))
+        digits (mapv char (range 48 58))
+        symbols (concatv (map char (range 33 48))
+                         (map char (range 91 97))
+                         (map char (range 123 127)))]
+    {:alpha (concatv alpha ALPHA)
+     :alpha-lower alpha
+     :alpha-upper ALPHA
+     :alpha-digits (concatv alpha ALPHA digits)
+     :alpha-digits-symbols (concatv alpha ALPHA digits symbols)
+     :symbols symbols
+     :digits digits}))
+
+(defn rand-str
+  "Produces a random string of length n, drawn from the given collection of
+  characters. The following keywords may be used in place of a character
+  collection:
+    :alpha - [a-zA-Z]
+    :alpha-lower - [a-z]
+    :alpha-upper - [A-Z]
+    :alpha-digits - [a-zA-Z0-9]
+    :alpha-digits-symbols - all printable ASCII characters besides space
+    :symbols - all visible, non-alpha-numeric ASCII characters (no space)
+    :digits - [0-9]
+  If no character collection or keyword is provided, :alpha-digits-symbols is
+  used by default."
+  ([n] (rand-str :alpha-digits-symbols n))
+  ([characters n]
+   (let [char-coll (cond
+                     (and (keyword? characters) (contains? ascii-character-sets characters))
+                     (get ascii-character-sets characters)
+
+                     (keyword? characters)
+                     (throw (IllegalArgumentException.
+                              (str characters " is not a recognized character collection keyword")))
+
+                     :else (vec characters))]
+     (apply str (repeatedly n #(rand-nth char-coll))))))
+
 ;; ## Collection operations
 
 (defn symmetric-difference

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -204,6 +204,22 @@
       (testing "a weight is not numeric"
         (is (thrown? AssertionError (rand-weighted-selection :foo :bar)))))))
 
+(deftest rand-str-test
+  (testing "rand-str"
+    (testing "throws an IllegalArgumentException when given an unknown characters keyword"
+      (is (thrown-with-msg? IllegalArgumentException #":CJK" (rand-str :CJK 42))))
+
+    (doseq [[kw cs] ascii-character-sets
+            :let [cs (set cs)]]
+      (testing (str "recognizes the " kw " character set keyword")
+        (dotimes [_ 10]
+          (is (every? cs (rand-str kw 1000))))))
+
+    (testing "uses collections of strings & characters as character sets"
+      (let [as ["a" \a]]
+        (dotimes [_ 100]
+          (is (every? #(= % \a) (rand-str as 100))))))))
+
 (deftest excludes?-test
   (testing "should return true if coll does not contain key"
     (is (excludes? {:foo 1} :bar)))


### PR DESCRIPTION
Add `rand-str` to the core namespace, which produces a random string of
variable length whose characters come from a given collection of
characters or from a pre-defined character set that is selected by
providing one of `:alpha`, `:alpha-lower`, `:alpha-upper`,
`:alpha-digits`, `:alpha-digits-symbols`, `:symbols`, or `:digits`.