### PR TITLE
(maint) add deref-swap!

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -1043,3 +1043,14 @@ to be a zipper."
                           :when (= ::not-found (get ~map k# ::not-found))]
                       [k# (v#)])]
        (merge ~map (into {} updates#)))))
+
+(defn deref-swap!
+  "Like swap! but returns the old value.
+   Adapted from http://stackoverflow.com/a/15442107."
+  [atom f & args]
+  (loop []
+    (let [old @atom
+          new (apply f old args)]
+      (if (compare-and-set! atom old new)
+        old
+        (recur)))))

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -751,3 +751,10 @@
            (assoc-if-new {:b nil} :a "foo" :b "bar")))
     (is (= {:a "foo" :b "baz"}
            (assoc-if-new {:b "baz"} :a "foo" :b "bar")))))
+
+(deftest deref-swap-test
+  (testing "deref-swap behaves as advertised"
+    (let [a (atom 10)
+          b (deref-swap! a inc)]
+      (is (= 11 @a))
+      (is (= 10 b)))))


### PR DESCRIPTION
deref-swap! works like swap but returns the old value instead of the new
one.