### PR TITLE
(maint) update release notes for 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,16 @@ Features:
   the key does not already exist in the map.
 * Add a `deref-swap!` function, which behaves like deref but returns the old
   value instead of the new one.
+* Add a `rand-str` function, for generating random strings from various
+  character sets.
 
 Maintenance:
 
 * Update to dynapath 0.2.5, to address some compatability issues with Java 9.
+
+## 2.1.1
+
+The 2.1.1 release was burned and folded into 2.2.0.
 
 ## 2.1.0
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/kitchensink "2.1.2-SNAPSHOT"
+(defproject puppetlabs/kitchensink "2.2.0-SNAPSHOT"
   :description "Clojure utility functions"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}


### PR DESCRIPTION
2.2.0 was released today as 2.1.1. This is a rerelease with the addition
of the rand-str function.