### PR TITLE
(maint) add a parser for period strings (7d, 12h, etc)

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -20,7 +20,7 @@
         [clojure.string :only (split)]
         [clojure.stacktrace :only (print-cause-trace)]
         [clojure.pprint :only [pprint]]
-        [clj-time.core :only [now]]
+        [clj-time.core :only [now seconds minutes hours days years]]
         [clj-time.coerce :only [ICoerce to-date-time]]
         [clj-time.format :only [formatters unparse]]))
 
@@ -1095,3 +1095,27 @@ to be a zipper."
       (if (compare-and-set! atom old new)
         old
         (recur)))))
+
+(defn parse-interval
+  "Given a time string of the form \"<number>\", or \"<number><unit>\", this
+  function parses this time amount and returns a joda time Period instance.
+  If the unit is left off, the units are assumed to be seconds
+
+  Example: \"12h\" -> (clj-time.core/hours 12)
+  Example: \"12\" -> (clj-time.core/seconds 12)
+
+  Possible units: s(econds), m(inutes), h(ours), d(ays), y(ears)
+
+  Returns nil if the time string cannot be parsed."
+  [time-str]
+  (when-not (nil? time-str)
+    (when-let [[_ num unit] (re-matches #"^(\d+)([smhdy]?)$" time-str)]
+      (let [num (parse-int num)
+            time-fn (case unit
+                      "s" seconds
+                      "m" minutes
+                      "h" hours
+                      "d" days
+                      "y" years
+                      "" seconds)]
+        (time-fn num)))))

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -4,6 +4,7 @@
             [me.raynes.fs :as fs]
             [slingshot.slingshot :refer [try+]]
             [clojure.string :as string]
+            [clj-time.core :as t]
             [puppetlabs.kitchensink.testutils :as testutils]
             [clojure.zip :as zip])
   (:import (java.util ArrayList)))
@@ -774,3 +775,20 @@
           b (deref-swap! a inc)]
       (is (= 11 @a))
       (is (= 10 b)))))
+
+(deftest parse-interval-test
+  (are [x y] (= x (parse-interval y))
+    (t/seconds 11) "11s"
+    (t/minutes 12) "12m"
+    (t/hours 13) "13h"
+    (t/days 14) "14d"
+    (t/years 15) "15y"
+    (t/seconds 0) "0"
+    (t/seconds 10) "10"
+    nil "15a"
+    nil "h"
+    nil "12hhh"
+    nil "12H"
+    nil "1,300y"
+    nil ""
+    nil nil))


### PR DESCRIPTION
This takes the period string parser from RBAC. It or an equivalent is
used in RBAC and PuppetDB, and I'd like to use it in the PCP broker now
as well.