### PR TITLE
(SERVER-1926) add {utf8-string,file}->sha256 functions

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -965,6 +965,15 @@ to be a zipper."
   (let [bytes (.getBytes s "UTF-8")]
     (digest/sha-1 [bytes])))
 
+(defn utf8-string->sha256
+  "Compute a SHA-256 hash for the UTF-8 encoded version of the supplied
+  string"
+  [^String s]
+  {:pre  [(string? s)]
+   :post [(string? %)]}
+  (let [bytes (.getBytes s "UTF-8")]
+    (digest/sha-256 [bytes])))
+
 (defn bounded-memoize
   "Similar to memoize, but the cache will be reset if the number of entries
   exceeds the specified `bound`."

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -974,6 +974,15 @@ to be a zipper."
   (let [bytes (.getBytes s "UTF-8")]
     (digest/sha-256 [bytes])))
 
+(defn file->sha256
+  "Compute a SHA-256 hash for the given java.io.File object.
+  Uses an InputStream to read the file, so it doesn't load all the contents into
+  memory at once."
+  [^java.io.File file]
+  {:pre  [(instance? java.io.File file)]
+   :post [(string? %)]}
+  (digest/sha-256 file))
+
 (defn bounded-memoize
   "Similar to memoize, but the cache will be reset if the number of entries
   exceeds the specified `bound`."

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -416,7 +416,19 @@
 
     (testing "should produce the correct hash"
       (is (= "8843d7f92416211de9ebb963ff4ce28125932878"
-            (utf8-string->sha1 "foobar"))))))
+             (utf8-string->sha1 "foobar")))))
+
+  (testing "Computing a SHA-256 for a UTF-8 string"
+    (testing "should fail if not passed a string"
+      (is (thrown? AssertionError (utf8-string->sha256 1234))))
+
+    (testing "should produce a stable hash"
+      (is (= (utf8-string->sha256 "foobar")
+             (utf8-string->sha256 "foobar"))))
+
+    (testing "should produce the correct hash"
+      (is (= "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"
+             (utf8-string->sha256 "foobar"))))))
 
 (deftest temp-file-name-test
   (testing "The file should not exist."

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -430,6 +430,22 @@
       (is (= "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"
              (utf8-string->sha256 "foobar"))))))
 
+(deftest file-hashing
+  (testing "Computing a SHA-256 hash for a file"
+    (testing "should fail if not passed a file"
+      (is (thrown? AssertionError (file->sha256 "what"))))
+
+    (let [f (temp-file "sha256" ".txt")]
+      (spit f "foobar")
+
+      (testing "should produce a stable hash"
+        (is (= (file->sha256 f)
+               (file->sha256 f))))
+
+      (testing "should produce the correct hash"
+        (is (= "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"
+               (file->sha256 f)))))))
+
 (deftest temp-file-name-test
   (testing "The file should not exist."
     (is (not (fs/exists? (temp-file-name "foo")))))


### PR DESCRIPTION
The `utf8-string->sha256` function is exactly analogous to the existing `utf8-string->sha1` function.

The `file->sha256` function is similar, but operates on a `java.io.File` object, and it both saves a round-trip from bytes to string to bytes again and avoids loading the entire file into memory at once.