### PR TITLE
(maint) Fix Clojure 1.9 warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.5.1
+
+This is a minor maintenance release.
+
+Maintenance:
+* Fix symbol redef warnings under Clojure 1.9
+
 ## 2.5.0
 
 This is a minor feature release.

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -5,6 +5,7 @@
 ;; altogether. But who has time for that?
 
 (ns puppetlabs.kitchensink.core
+  (:refer-clojure :exclude [boolean? uuid?])
   (:import [org.ini4j Ini Config BasicProfileSection]
            [javax.naming.ldap LdapName]
            [java.io StringWriter Reader File])


### PR DESCRIPTION
In verison 1.9, clojure gets the boolean? and uuid? predicates in clojure.core.
Exclude these from kitchensink.core to avoid duplicate definition warnings.