### PR TITLE
(maint) Fix classpath stuff for Java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: clojure
 jdk:
+  - oraclejdk9
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
-  - openjdk6
 notifications:
   email: false
   hipchat:

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [cheshire]
 
                  [org.ini4j/ini4j "0.5.2"]
-                 [org.tcrawley/dynapath "0.2.5"]
+                 [org.tcrawley/dynapath "1.0.0"]
                  [digest "1.4.3"]
 
                  ]

--- a/test/puppetlabs/kitchensink/classpath_test.clj
+++ b/test/puppetlabs/kitchensink/classpath_test.clj
@@ -1,12 +1,19 @@
 (ns puppetlabs.kitchensink.classpath-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.kitchensink.classpath :refer [with-additional-classpath-entries]])
-  (:import (java.net URL)))
+            [dynapath.dynamic-classpath :refer [classpath-urls]]
+            [puppetlabs.kitchensink.classpath :refer [add-classpath
+                                                      with-additional-classpath-entries]])
+  (:import (java.net URL))
+  (:refer-clojure :exclude (add-classpath)))
 
 (deftest with-additional-classpath-entries-test
   (let [paths ["/foo" "/bar"]
         get-urls #(into #{}
-                        (.getURLs (.getContextClassLoader (Thread/currentThread))))]
+                        (classpath-urls (.getContextClassLoader (Thread/currentThread))))]
+    ;; Called for side effect of ensuring there's a modifiable classloader
+    ;; without needing to make that function public
+    (add-classpath "file:/nil")
+
     (with-additional-classpath-entries
       paths
       (testing "classloader now includes the new paths"

--- a/test/puppetlabs/kitchensink/classpath_test.clj
+++ b/test/puppetlabs/kitchensink/classpath_test.clj
@@ -1,26 +1,17 @@
 (ns puppetlabs.kitchensink.classpath-test
   (:require [clojure.test :refer :all]
-            [dynapath.dynamic-classpath :refer [classpath-urls]]
-            [puppetlabs.kitchensink.classpath :refer [add-classpath
-                                                      with-additional-classpath-entries]])
-  (:import (java.net URL))
-  (:refer-clojure :exclude (add-classpath)))
+            [puppetlabs.kitchensink.classpath :refer [with-additional-classpath-entries]])
+  (:import (java.net URL)))
 
 (deftest with-additional-classpath-entries-test
-  (let [paths ["/foo" "/bar"]
-        get-urls #(into #{}
-                        (classpath-urls (.getContextClassLoader (Thread/currentThread))))]
-    ;; Called for side effect of ensuring there's a modifiable classloader
-    ;; without needing to make that function public
-    (add-classpath "file:/nil")
-
+  (let [paths ["classpath-test"]
+        get-resource #(-> (Thread/currentThread)
+                          .getContextClassLoader
+                          (.getResource "does-not-exist-anywhere-else"))]
     (with-additional-classpath-entries
       paths
-      (testing "classloader now includes the new paths"
-        (let [urls (get-urls)]
-          (is (contains? urls (URL. "file:/foo")))
-          (is (contains? urls (URL. "file:/bar"))))))
-    (testing "classloader has been restored to its previous state"
-      (let [urls (get-urls)]
-        (is (not (contains? urls (URL. "file:/foo"))))
-        (is (not (contains? urls (URL. "file:/bar"))))))))
+      (testing "classloader now includes the new path"
+        (is (get-resource))))
+
+    (testing "classloader no longer includes the new path"
+      (is (not (get-resource))))))


### PR DESCRIPTION
We can't rely on having a modifiable classloader at all times, so make
sure one is put in place if needed.

Fixes #79 