### PR TITLE
(maint) Disable slow test by default

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,6 +40,9 @@
   :plugins [[lein-project-version "0.1.0"]
             [lein-parent "0.3.1"]]
 
+  :test-selectors {:default (complement :slow)
+                   :slow :slow}
+
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
                                      :password :env/clojars_jenkins_password

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -792,7 +792,7 @@
                (with-timeout 1 false
                  (wait-return 1005 true))))))))
 
-(deftest open-port-num-test
+(deftest ^:slow open-port-num-test
   (let [port-in-use (open-port-num)]
     (with-open [s (java.net.ServerSocket. port-in-use)]
       (let [open-ports (set (take 60000 (repeatedly open-port-num)))]


### PR DESCRIPTION
This test takes over a minute and doesn't add much in normal runs.