### PR TITLE
(PE-29968) Don't select an open port from the ephemeral port range

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -1099,15 +1099,19 @@ to be a zipper."
         (throw e)))))
 
 (defn open-port-num
-  "Returns a currently open port number in the traditional ephemeral port range
-  of 49152 through 65535."
+  "Returns a currently open port number in the port range 16384
+  through 32767. Note that on Linux, anything above 32767 lies in
+  the ephemeral port range, which is the range that the system uses
+  to allocate ports upon user request. Thus, we choose from a
+  different range to prevent possible port conflicts caused by
+  various services (e.g. database connection pools)."
   []
-  (let [lo 49152
-        hi 65536] ; one higher because the upper limit is exclusive
+  (let [lo 16384
+        hi 32768] ; one higher because the upper limit is exclusive
     (if-let [open-port (some port-open? (shuffle (range lo hi)))]
       open-port
       (throw (java.net.BindException.
-               "All ephemeral ports are already in use (Bind failed)")))))
+               (format "All ports in the range %d through %d are already in use (Bind failed)" lo (dec hi)))))))
 
 (defmacro assoc-if-new
   "Assocs the provided values with the corresponding keys if and only


### PR DESCRIPTION
We've been seeing a lot of port binding failures in CI. These failures
typically adopt the following pattern:

* open-port-num select open ports for a bunch of services (e.g.
classifier, puppetserver)

* Trapperkeeper boots these services, including their dependencies

* Some of these dependencies request an open port from the system, which
picks a port from the ephemeral port range. Since the main service(s)
haven't started yet, there's a chance this port could match one of the
ports picked by open-port-num.

Thus, the dependency will start, but the corresponding service will fail
with the port binding error because its open port was taken by the
dependency. Database connection pools are an example of one such dependency.

The solution here is for open-port-num to select from a different range.
We choose 16384 - 32767, inclusive, because 32768 is the lower bound of
Linux's ephemeral port range and 16384 gives us the same number of ports
to select from as the ephemeral port range (16384).

NOTE: In containers, the system will _randomly_ select an ephemeral
port (like open-port-num) instead of adopt a predictable pattern like on a
Mac machine. This makes conflicts far more likely. Since our CI runs
these tests in a container, this explains why we've been seeing the port
binding failure so frequently in CI than on e.g. localhost (at least on
Mac).

Signed-off-by: Enis Inan <enis.inan@puppet.com>