### PR TITLE
(PE-31121) add base-type function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.3
+
+* Add base-type function that returns the base type from an HTTP Content-Type header.
+
 ## 3.1.2
 
 * Update clj-parent to resolve some outdated dependencies with security issues.

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -1159,3 +1159,16 @@ to be a zipper."
                       "y" time/years
                       "" time/seconds)]
         (time-fn num)))))
+
+;; ## HTTP Headers
+
+(defn base-type
+  "Parse a base type out of a Content-Type, returns nil if there's no match.
+  Does not validate any parameters."
+  ;; Content-Type header grammar https://tools.ietf.org/html/rfc7231#section-3.1.1.1
+  ;; token definition https://tools.ietf.org/html/rfc7230#section-3.2.6
+  ;; white space definition https://tools.ietf.org/html/rfc7230#section-3.2.3
+  [content-type]
+  (let [token #"[a-zA-Z0-9!#$%&'*+.^_`|~-]+"
+        matcher (format "^(%s/%s)(?:[ \t;]|$)" token token)]
+    (second (re-find (re-pattern matcher) content-type))))

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -835,3 +835,13 @@
     nil "1,300y"
     nil ""
     nil nil))
+
+(deftest base-type-test
+  (is (= "application/json" (base-type "application/json")))
+  (is (= "application/json" (base-type "application/json;charset=UTF-8")))
+  (is (= "application/json" (base-type "application/json ; charset=UTF-8")))
+
+  (is (= "foo/bar" (base-type "foo/bar;someparam=baz")))
+
+  (is (nil? (base-type "application/json:charset=UTF-8")))
+  (is (nil? (base-type "appl=ication/json ; charset=UTF-8"))))


### PR DESCRIPTION
This commit adds a new function to return the base type of an
HTTP Content-Type header.