### PR TITLE
(PE-33707) Add a keyword->str function

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -1172,3 +1172,11 @@ to be a zipper."
   (let [token #"[a-zA-Z0-9!#$%&'*+.^_`|~-]+"
         matcher (format "^(%s/%s)(?:[ \t;]|$)" token token)]
     (second (re-find (re-pattern matcher) content-type))))
+
+(defn keyword->str
+  "Alternate implementation for `name`, which has unintended effects when trying to discard namespace
+   For example the keyword :/foo will be resolved to :foo using `name` but this function will transform
+   the keyword :/foo to the string /foo"
+  [kw]
+  {:pre [(keyword? kw)]}
+  (subs (str kw) 1))

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -845,3 +845,7 @@
 
   (is (nil? (base-type "application/json:charset=UTF-8")))
   (is (nil? (base-type "appl=ication/json ; charset=UTF-8"))))
+
+(deftest keyword->str-test
+  (is (= "/foo" (keyword->str (keyword "/foo"))))
+  (is (= ":::" (keyword->str (keyword ":::")))))


### PR DESCRIPTION
In serveral services the clojure `name` function is being used for turning keywords in to strings. The behavior of the `name` function https://clojuredocs.org/clojure.core/name around dropping namespace from the key name is not desired in some cases. In some cases we just want a literal string representation of the keyword without the preceeding colon character. This commit introduces a new function to do this transformation.