### PR TITLE
(PE-33707) Add key->str function to convert keywords to strings

### DIFF
--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -141,6 +141,14 @@ to be a zipper."
       (> num-strings 3)
       (str (first strings) ", " (to-sentence (rest strings))))))
 
+(defn key->str
+  "Convert a keyword to a string, stripping the leading : character. This is
+  distinct from the `name` function as it will preserve the 'namespace' portion
+  before a slash. If the key is already a string, it is returned unmodified."
+  [kw]
+  (if (keyword? kw)
+    (subs (str kw) 1)
+    kw))
 
 ;; ## I/O
 

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -108,6 +108,17 @@
        ["foo" "bar" "baz"] "foo, bar, and baz"
        ["foo" "bar" "baz" "qux"] "foo, bar, baz, and qux"))
 
+(deftest key->str-test
+  (testing "returns strings unmodified"
+    (is (= "foo" (key->str "foo")))
+    (is (= ":foo" (key->str ":foo")))
+    (is (= "foo/bar" (key->str "foo/bar"))))
+
+  (testing "returns the entire stringified keyword"
+    (is (= "foo" (key->str :foo)))
+    (is (= ":foo" (key->str (keyword ":foo"))))
+    (is (= "foo/bar" (key->str :foo/bar)))))
+
 (deftest mkdirs-test
   (testing "creates all specified directories that don't exist for File arg"
     (let [tmpdir (temp-dir)]


### PR DESCRIPTION
We typically use the `name` function to convert keywords to strings,
which is usually correct but has a subtle bug: if the keyword contains a
slash, `name` only returns the portion after the slash, as the portion
before that is considered the namespace.

This commit adds a new `key->str` function which accepts both keywords
and strings and returns the properly stringified version (with the
leading : removed for keywords). Accepting both keywords and strings
allows it to be used to normalize map keys parsed from JSON without
worrying where they came from.