### PR TITLE
fix snyk key in action

### DIFF
--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -23,7 +23,7 @@ jobs:
       id: scan
       uses: puppetlabs/security-snyk-clojure-action@v2
       with:
-        snykToken: ${{ secrets.SNYK_GENERAL_KEY }}
+        snykToken: ${{ secrets.SNYK_PE_KEY }}
         snykOrg: 'puppet-enterprise'
         snykPolicy: '.snyk'
     - name: Check output


### PR DESCRIPTION
this changes the snyk token from the general token to the PE token since the general token can't see the `puppet-enterprise` snyk org