### PR TITLE
(maint) Fix Snyk token name

### DIFF
--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -23,7 +23,7 @@ jobs:
       id: scan
       uses: puppetlabs/security-snyk-clojure-action@v2
       with:
-        snykToken: ${{ secrets.SNYK_PE_KEY }}
+        snykToken: ${{ secrets.SNYK_PE_TOKEN }}
         snykOrg: 'puppet-enterprise'
         snykPolicy: '.snyk'
     - name: Check output


### PR DESCRIPTION
The secret in this repo is called `SNYK_PE_TOKEN`, not `SNYK_PE_KEY`, whoops.