### PR TITLE
(maint) add java-time conversion functions, update clj-parent and changeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## unreleased
-* add conversion functions from string -> ZonedDateTime -> string
+* add conversion functions from string -> ZonedDateTime -> string to facilitate the removal of clj-time
+* update clj-parent to 5.3.7
 
 ## 3.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## unreleased
+* add conversion functions from string -> ZonedDateTime -> string
+
 ## 3.2.1
 
 * Update ini4j to 0.5.4 to address a Denial of Service

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.6.17"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.3.7"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in


### PR DESCRIPTION
In first commit:

[clj-time](https://github.com/clj-time/clj-time) and [joda-time](https://www.joda.org/joda-time/)
are both in a deprecated state since the [java.time APIs](https://docs.oracle.com/javase/8/docs/technotes/guides/datetime/index.html) became available and
supports the same functionality.

In second commit:
This updates clj-parent to 5.3.7, and updates the changelog to
reflect the recent changes.
