### PR TITLE
(maint) remove deprecated interface, add version function

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,2 +1,3 @@
-{:linters {:refer-all {:exclude [clojure.test slingshot.test]}}
+{:linters {:refer-all {:exclude [clojure.test slingshot.test]}
+           :deprecated-var {:exclude {puppetlabs.kitchensink.core/cn-for-dn {:namespaces [puppetlabs.kitchensink.core puppetlabs.kitchensink.core-test]}}}}
  :output {:linter-name true}}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pom.xml
 /target/
 .lein-deps-sum
 .lein-failures
+.clj-kondo/.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## unreleased
-* change use of java.security.cert.X509Certificate/getSubjectDN, which is now deprecated, to java.security.cert.X509Certificate/getSubjectX500Principal  
+* change use of java.security.cert.X509Certificate/getSubjectDN, which is now deprecated, to java.security.cert.X509Certificate/getSubjectX500Principal
+* add function `get-lein-project-version` to retrieve a given project version from the standard `lein` system properties.
 
 ## 3.2.3
 * add clj-kondo linting, eastwood linting, and PR testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased
 * change use of java.security.cert.X509Certificate/getSubjectDN, which is now deprecated, to java.security.cert.X509Certificate/getSubjectX500Principal
 * add function `get-lein-project-version` to retrieve a given project version from the standard `lein` system properties.
+* mark deprecated interfaces with metadata deprecation
 
 ## 3.2.3
 * add clj-kondo linting, eastwood linting, and PR testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased
+* change use of java.security.cert.X509Certificate/getSubjectDN, which is now deprecated, to java.security.cert.X509Certificate/getSubjectX500Principal  
 
-# 3.2.3
+## 3.2.3
 * add clj-kondo linting, eastwood linting, and PR testing
 * address issues identified by clj-kondo, and eastwood
 * add function equivalent of puppet's versioncmp function, and helper functions for to determine if strings have all numeric characters and if strings start with a leading zero.

--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,8 @@
   :eastwood {:ignored-faults {:unused-ret-vals {puppetlabs.kitchensink.classpath [{:line 93}]}
                               :deprecations {puppetlabs.kitchensink.classpath [{:line 66}
                                                                                {:line 91}]
-                                             puppetlabs.kitchensink.core [{:line 941}]}
+                                             puppetlabs.kitchensink.core true
+                                             puppetlabs.kitchensink.core-test true}
                               :reflection {puppetlabs.kitchensink.file [{:line 62}]
                                            puppetlabs.kitchensink.core [{:line 929}]}
                               :constant-test {puppetlabs.kitchensink.core-test [{:line 726}

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -938,7 +938,7 @@ to be a zipper."
   If no CN exists in the certificate DN, nil is returned."
   [^java.security.cert.X509Certificate cert]
   (-> cert
-    (.getSubjectDN)
+    (.getSubjectX500Principal)
     (.getName)
     (cn-for-dn)))
 

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -900,8 +900,8 @@ to be a zipper."
 ;; These functions are only used by PuppetDB and they should likely move back into that
 ;; project until they can be refactored away over functions from the jvm-ca library.
 
-(defn cn-for-dn
-  "Deprecated. Use functions from `jvm-certificate-authority`.
+(defn ^:deprecated cn-for-dn
+  "Deprecated. Use functions from https://github.com/puppetlabs/jvm-ssl-utils instead.
 
   Extracts the CN (common name) from an LDAP DN (distinguished name).
 
@@ -929,8 +929,8 @@ to be a zipper."
     (.getValue)
     (str)))
 
-(defn cn-for-cert
-  "Deprecated. Use functions from `jvm-certificate-authority`.
+(defn ^:deprecated cn-for-cert
+  "Deprecated. Use functions from https://github.com/puppetlabs/jvm-ssl-utils instead.
 
   Extract the CN from the DN of an x509 certificate. See `cn-for-dn` for details
   on how extraction is performed.

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -1060,6 +1060,11 @@ to be a zipper."
   "Returns a string of the currently running java version"
   (System/getProperty "java.version"))
 
+(defn get-lein-project-version
+  "Get the version of the specified leinigen project from the runtime."
+  [project]
+  (System/getProperty (format "%s.version" project)))
+
 ;; control flow
 
 (defmacro cond-let

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -1001,3 +1001,10 @@
     (is (pos? (core/compare-versions "2.0" "1.1.a")))
     (is (neg? (core/compare-versions "2.4" "2.4b")))
     (is (pos? (core/compare-versions "2.4b" "2.4a")))))
+
+(deftest get-lein-project-version-test
+  (testing "unknown project returns nil"
+    (is (nil? (core/get-lein-project-version "unknown"))))
+  (testing "known project returns something"
+    (is (string? (core/get-lein-project-version "kitchensink")))
+    (is (not (string/blank? (core/get-lein-project-version "kitchensink"))))))


### PR DESCRIPTION
The first commit removes the use of the deprecated `getSubjectDN` and replaces it with `getSubjectX500Principal` instead.

The second commit adds a new function `get-lein-project-version` which can be used to get a project version.  One use case is to log the version of projects used in an application.

It also adds the `deprecated` meta tag to a couple of routines that are functionally replaced with versions in `jvm-ssl-utils`