### PR TITLE
(maint) add `delete-recursively` function to files namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * add 'untar-file' routine to the files namespace to decompress tar files
 * update clj-parent to 5.6.6
 * remove reflection use in atomic-write
-
+* add function `delete-recursively` to the files namespace to recursively delete a directory
+* 
 ## 3.2.3
 * add clj-kondo linting, eastwood linting, and PR testing
 * address issues identified by clj-kondo, and eastwood


### PR DESCRIPTION
This adds a function `delete-recursively` that given a path to a file or directory as a string, will attempt to delete the file, or the contents of the directory tree. If at any point in the traversal a file or directory can't be removed, the recursion stops, and the function returns false.

Otherwise the function will return true if all the files and directories could be deleted.