### PR TITLE
(maint) ensure writer is closed if exception is thrown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+## 3.2.5
+* in `atomic-write` ensure the writer is closed if the `write-function` throws an exception.
+
 ## 3.2.4
 * change use of java.security.cert.X509Certificate/getSubjectDN, which is now deprecated, to java.security.cert.X509Certificate/getSubjectX500Principal
 * add function `get-lein-project-version` to retrieve a given project version from the standard `lein` system properties.

--- a/src/puppetlabs/kitchensink/file.clj
+++ b/src/puppetlabs/kitchensink/file.clj
@@ -72,12 +72,10 @@
                      (.sync (.getFD ^FileOutputStream this))
                      ;; this looks weird, but makes the proxy-super avoid reflection by masking `this` with a version that has the meta tag
                      (let [^FileOutputStream this this]
-                       (proxy-super close))))
-         writer (BufferedWriter. (OutputStreamWriter. stream))]
+                       (proxy-super close))))]
 
-     (write-function writer)
-
-     (.close writer)
+     (with-open [writer (BufferedWriter. (OutputStreamWriter. stream))]
+       (write-function writer))
 
      (when owner
        (Files/setOwner temp-file owner))


### PR DESCRIPTION
In the `atomic-write` behavior, if an exception is thrown in the `write-function` implementation, the associated writer would not be properly closed. This ensures the writer is closed regardless of the behavior of `write-function`