### PR TITLE
(maint) add puppet setting duration conversion functions, update clj-parent, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## unreleased
 
+## 3.3.0
+* add new functions `duration-str->seconds` and `duration-str->Duration` to calculate duration values in the style of Puppet duration settings resulting in an integer and a java.time.Duration respectively
+* add new function `safe-parse-int` to convert a number or string representing a to a number
+* update clj-parent to 5.6.14
+
 ## 3.2.5
 * in `atomic-write` ensure the writer is closed if the `write-function` throws an exception.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/kitchensink "3.2.6-SNAPSHOT"
+(defproject puppetlabs/kitchensink "3.3.0-SNAPSHOT"
   :description "Clojure utility functions"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "5.6.6"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.6.14"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -907,6 +907,11 @@ to be a zipper."
 ;; These functions are only used by PuppetDB and they should likely move back into that
 ;; project until they can be refactored away over functions from the jvm-ca library.
 
+(defn- safe-value-request
+  "Used to make eastwood happy about the type"
+  [^Rdn v]
+  (.getValue v))
+
 (defn ^:deprecated cn-for-dn
   "Deprecated. Use functions from https://github.com/puppetlabs/jvm-ssl-utils instead.
 
@@ -929,12 +934,12 @@ to be a zipper."
   [^String dn]
   {:pre [(string? dn)]}
   (some->> dn
-    (LdapName.)
-    (.getRdns)
-    (filter #(= "CN" (.getType ^Rdn %)))
-    (first)
-    (.getValue)
-    (str)))
+           (LdapName.)
+           (.getRdns)
+           (filter #(= "CN" (.getType ^Rdn %)))
+           (first)
+           (safe-value-request)
+           (str)))
 
 (defn ^:deprecated cn-for-cert
   "Deprecated. Use functions from https://github.com/puppetlabs/jvm-ssl-utils instead.

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -226,6 +226,13 @@ to be a zipper."
     (catch NumberFormatException _e
       nil)))
 
+(defn safe-parse-int
+  "Accept strings or integers. If string, parse to an integer, otherwise return the integer"
+  [s]
+  (if (integer? s)
+    s
+    (parse-int s)))
+
 (defn parse-float
   "Parse a string `s` as a float, returning nil if the string doesn't
   contain a float"

--- a/src/puppetlabs/kitchensink/file.clj
+++ b/src/puppetlabs/kitchensink/file.clj
@@ -129,14 +129,14 @@
         ;; allocate the copy buffer once and reuse for efficiency.
         buffer (ByteBuffer/allocateDirect (* 64 1024))]
     (with-open [tar-input-stream (TarArchiveInputStream. (io/input-stream path-to-tar-file))]
-      (loop [entry (.getNextTarEntry tar-input-stream)]
+      (loop [entry (.getNextEntry tar-input-stream)]
         (when (some? entry)
           (if (.isDirectory entry)
             (Files/createDirectories (dir+file->path trimmed-output (.getName entry)) empty-file-attributes)
             (let [output-file (dir+file->path trimmed-output (.getName entry))]
               (io/make-parents output-file)
               (write-tar-stream-to-file tar-input-stream output-file buffer)))
-          (recur (.getNextTarEntry tar-input-stream)))))))
+          (recur (.getNextEntry tar-input-stream)))))))
 
 (defn delete-recursively
   "Given a path to a directory, delete everything in the directory recursively.

--- a/src/puppetlabs/kitchensink/time.clj
+++ b/src/puppetlabs/kitchensink/time.clj
@@ -1,0 +1,28 @@
+(ns puppetlabs.kitchensink.time
+  (:require [puppetlabs.kitchensink.core :as core])
+  (:import (java.time Duration)))
+
+(def matching-pattern #"^(\d+)(y|d|h|m|s)?$")
+(def unit-map {"y" (* 365 24 60 60),                        ; 365 days isn't technically a year, but is sufficient for most purposes
+               "d" (* 24 60 60),
+               "h" (* 60 60),
+               "m" 60,
+               "s" 1})
+
+(defn duration-str->seconds
+  "Given a puppet duration string, see https://github.com/puppetlabs/puppet/blob/fb44fd90c64ee11f0a29fb8924adbab5b0695555/lib/puppet/settings/duration_setting.rb
+  for a reference implementation, return the duration in seconds"
+  [duration]
+  ;; handle both integer input and strings that parse as integers
+  (if-let [parsed-seconds (core/safe-parse-int duration)]
+    parsed-seconds
+    ;; must be a format string
+    (let [matches (re-seq matching-pattern duration)]
+      (if-let [last-matches (last matches)] ;; in the form [<matched string> <first-group> <second-group>]
+        (* (core/parse-int (second last-matches)) (get unit-map (last last-matches)))
+        (throw (IllegalArgumentException. (format "Invalid duration format %s" duration)))))))
+
+(defn duration-str->Duration
+  "Given a puppet duration string, return a java.time.Duration equivalent"
+  ^Duration [duration]
+  (Duration/ofSeconds (duration-str->seconds duration)))

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -1008,3 +1008,12 @@
   (testing "known project returns something"
     (is (string? (core/get-lein-project-version "kitchensink")))
     (is (not (string/blank? (core/get-lein-project-version "kitchensink"))))))
+
+(deftest safe-parse-int-test
+  (testing "Converts appropriately"
+    (are [x y] (= x (core/safe-parse-int y))
+               0 0
+               1 1
+               0 "0"
+               1 "1"
+               nil "notanumber")))

--- a/test/puppetlabs/kitchensink/time_test.clj
+++ b/test/puppetlabs/kitchensink/time_test.clj
@@ -1,0 +1,43 @@
+(ns puppetlabs.kitchensink.time-test
+  (:require [clojure.test :refer :all])
+  (:require [puppetlabs.kitchensink.time :refer [duration-str->seconds duration-str->Duration]])
+  (:import (java.time Duration)))
+
+(deftest duration-str->seconds-test
+  (testing "returns an integer when given an integer"
+    (are [x] (= x (duration-str->seconds x))
+            -1 0 1 2 3 4 5 6 7 8 9 10))
+  (testing "returns expected values for simple input"
+    (are [x y] (= x (duration-str->seconds y))
+               94608000 "3y"
+               259200 "3d"
+               10800 "3h"
+               180 "3m"
+               3 "3s"))
+  (testing "Throws exceptions on invalid input"
+    (is (thrown? IllegalArgumentException (duration-str->seconds "6y3m3y")))
+    (is (thrown? IllegalArgumentException (duration-str->seconds "3y6d7d8d3d")))
+    (is (thrown? IllegalArgumentException (duration-str->seconds "3y3y6d7d3h")))
+    (is (thrown? IllegalArgumentException (duration-str->seconds "3y6y5h6d3m")))
+    (is (thrown? IllegalArgumentException (duration-str->seconds "3y6y5h6d3m3s")))
+    (is (thrown? IllegalArgumentException (duration-str->seconds "not-a-duration")))))
+
+(deftest duration-str->Duration-test
+  (testing "returns a duration with the expected number of seconds when given an integer"
+    (testing "returns an integer when given an integer"
+      (are [x] (= (Duration/ofSeconds x) (duration-str->Duration x))
+                 -1 0 1 2 3 4 5 6 7 8 9 10))
+    (testing "returns expected values for simple input"
+      (are [x y] (= (Duration/ofSeconds x) (duration-str->Duration y))
+                 94608000 "3y"
+                 259200 "3d"
+                 10800 "3h"
+                 180 "3m"
+                 3 "3s"))
+    (testing "Throws exceptions on invalid input"
+      (is (thrown? IllegalArgumentException (duration-str->Duration "6y3m3y")))
+      (is (thrown? IllegalArgumentException (duration-str->Duration "3y6d7d8d3d")))
+      (is (thrown? IllegalArgumentException (duration-str->Duration "3y3y6d7d3h")))
+      (is (thrown? IllegalArgumentException (duration-str->Duration "3y6y5h6d3m")))
+      (is (thrown? IllegalArgumentException (duration-str->Duration "3y6y5h6d3m3s")))
+      (is (thrown? IllegalArgumentException (duration-str->Duration "not-a-duration"))))))


### PR DESCRIPTION
Puppet has a setting option called Duration, which supports a single
number with an optional time descriptor (`y`, `d`, `m`, `s`).

This adds functions that convert the supported puppet duration values
into seconds and java.time.Duration accordingly.

An additional function to parse numbers and strings into numbers
was introduced as it is common in the consuming applications to do
this.